### PR TITLE
docs: 添加 Cursor Cloud 开发环境说明 (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+`mergev` is a terminal Git merge-conflict resolver (Node.js + TypeScript CLI with
+an Ink three-pane TUI). The implemented application currently lives on the
+`test/ink-cli` branch; the `main` branch holds only `docs/` and a skeleton
+`package.json` with no source or dependencies.
+
+### Toolchain
+
+- Package manager / dev runner: **bun** (installed at `~/.bun/bin`, already on
+  `PATH` via `~/.bashrc`).
+- User runtime: **Node.js >= 20** (the VM has Node 22).
+- Stack: TypeScript (ESM), Ink + React (TUI), commander (CLI), execa (git),
+  node-diff3 (merge model), tsup (build), tsx (dev), vitest (tests).
+
+### Commands (run where the app code exists, e.g. `test/ink-cli`)
+
+Standard scripts are defined in `package.json`:
+
+- Install dependencies: `bun install`
+- Dev run: `bun run dev` (runs `tsx src/cli/index.ts`)
+- Lint / typecheck: `bun run typecheck` (runs `tsc --noEmit`; there is no
+  separate ESLint config, so typecheck is the lint gate)
+- Tests: `bun run test` (runs `vitest run`)
+- Build: `bun run build` (runs `tsup`, emits `dist/cli.js`)
+
+### Non-obvious caveats
+
+- The git integration tests in `tests/git/git.test.ts` spawn many real `git`
+  subprocesses in temporary repos and are slow in this sandbox (individual tests
+  can take 8-21s). The default per-test timeout can produce a spurious timeout
+  on the `honors noAdd unless forceAdd is requested` case. Re-run those tests
+  with a higher timeout when needed: `bunx vitest run tests/git/git.test.ts
+  --testTimeout=60000`. The non-git test files are fast.
+- The interactive TUI requires a real TTY. In non-interactive contexts use
+  `mergev --list` or `mergev --porcelain`. To drive the TUI headlessly, run it
+  inside `tmux` (which provides a pty); the three-pane layout needs a terminal
+  width of >= 120 columns (80-119 renders two-pane, < 80 renders single-pane).
+- To run the CLI against a repository, invoke it from inside that repository
+  (it resolves the repo root from the current working directory).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

搭建本仓库的云端开发环境，并新增 `AGENTS.md` 记录未来 Cloud Agent 所需的启动/运行须知。

`main` 分支目前只有 `docs/` 与骨架 `package.json`，实际应用实现位于 `test/ink-cli` 分支。为验证工具链，我在一个 git worktree 中检出 `test/ink-cli` 完成了安装 / 类型检查 / 测试 / 构建 / 运行的端到端验证。

## 环境搭建

- 安装 **bun 1.3.14**（项目的包管理器，位于 `~/.bun/bin`，已通过 `~/.bashrc` 加入 PATH）。Node 22 已预装，满足 `>=20`。
- Update script：`$HOME/.bun/bin/bun install`（在 `main` 上是安全的空操作，代码合并后会安装全部依赖）。

## 变更内容

- 新增 `AGENTS.md`，包含 `## Cursor Cloud specific instructions`：工具链、标准命令（dev/typecheck/test/build）以及非显而易见的注意事项（git 集成测试在沙箱中较慢需提高超时、TUI 需要 TTY、三栏布局需 >=120 列）。通过 `markdownlint-cli2` 校验（0 error）。

## 验证（在 `test/ink-cli` 代码上）

- ✅ `bun install`
- ✅ `bun run typecheck`
- ✅ `bun run test`（24/25，唯一失败为 git 集成测试的环境超时；`bunx vitest run tests/git/git.test.ts --testTimeout=60000` 下 6/6 全通过）
- ✅ `bun run build`
- ✅ `mergev --list` / `--porcelain`（真实冲突仓库中检测并列出冲突文件）
- ✅ 三栏 TUI 端到端解决冲突并 `git add`

## 演示

[mergev_tui_resolve_conflicts_demo.mp4](https://cursor.com/agents/bc-6bf50978-3b48-4801-8119-0672c1e2ba19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmergev_tui_resolve_conflicts_demo.mp4)

三栏合并视图（Ours / Result / Theirs）：

[three pane view](https://cursor.com/agents/bc-6bf50978-3b48-4801-8119-0672c1e2ba19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmergev_three_pane_view.webp)

全部冲突解决后的状态：

[all resolved](https://cursor.com/agents/bc-6bf50978-3b48-4801-8119-0672c1e2ba19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmergev_all_resolved.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bf50978-3b48-4801-8119-0672c1e2ba19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bf50978-3b48-4801-8119-0672c1e2ba19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

